### PR TITLE
RabbitMQ: Ahora se pueden instalar plugins

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,7 +6,7 @@ This role installs and configures [RabbitMQ](https://www.rabbitmq.com/).
 Role Variables
 --------------
 
-None
+* **rabbitmq_plugins**: A comma-separated list of plugins to install
 
 Example Playbook
 ----------------

--- a/rabbitmq/defaults/main.yml
+++ b/rabbitmq/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for rabbitmq
+
+rabbitmq_plugins: false

--- a/rabbitmq/tasks/main.yml
+++ b/rabbitmq/tasks/main.yml
@@ -30,6 +30,14 @@
   notify: Restart rabbitmq
   tags: [rabbitmq]
 
+- name: Install plugins
+  rabbitmq_plugin:
+    names: '{{ rabbitmq_plugins }}'
+    state: 'enabled'
+  when: rabbitmq_plugins != false
+  notify: Restart rabbitmq
+  tags: [rabbitmq,rabbitmq-plugins]
+
 - name: Ensure rabbitmq is started and enabled on boot
   service:
     name: 'rabbitmq-server'

--- a/supervisord/README.md
+++ b/supervisord/README.md
@@ -1,0 +1,40 @@
+supervisord
+======
+
+This role installs supervisord, a simple process manager.
+
+Documentation: http://supervisord.org/
+
+Role Variables
+--------------
+
+* **supervisord_programs:** A list of programs to monitor. Check example for more details about the available parameters per entry.
+* **supervisord_log_path:** Path to store output from programs (default: "/var/log").
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+        - { 
+          role: supervisord
+          supervisord_log_path: '/var/log/supervisord'
+          supervisord_programs:
+            - name: 'consumer01'
+              command: 'app/console rabbitmq consumer'
+              directory: '/var/www/symfony-app'
+              numprocs: 1
+              autostart: true
+              autorestart: true
+              user: 'www-data'
+              stderr_logfile: 'supervisord-consumer01.err.log'
+              stdout_logfile: 'supervisord-consumer01.out.log'
+            - name: 'app'
+              process_name: 'app.py'
+              ...
+        }
+
+License
+-------
+
+BSD

--- a/supervisord/defaults/main.yml
+++ b/supervisord/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# defaults file for supervisord
+
+supervisord_log_path: '/var/log/supervisor'
+supervisord_program_defaults:
+  numprocs: 1
+  autostart: true
+  autorestart: true

--- a/supervisord/defaults/main.yml
+++ b/supervisord/defaults/main.yml
@@ -6,3 +6,4 @@ supervisord_program_defaults:
   numprocs: 1
   autostart: true
   autorestart: true
+  environment: ''

--- a/supervisord/handlers/main.yml
+++ b/supervisord/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+# handlers file for supervisord
+
+- name: Restart supervisord
+  service:
+    name: 'supervisor'
+    state: 'restarted'
+
+- name: Reload supervisord config
+  shell: 'supervisorctl reread; supervisorctl update'

--- a/supervisord/tasks/main.yml
+++ b/supervisord/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# tasks file for supervisord
+
+- name: Install required packages
+  apt:
+    name: 'supervisor'
+    state: 'installed'
+  tags: [supervisord,packages]
+
+- name: Ensure log path exists
+  file:
+    state: 'directory'
+    path: '{{ supervisord_log_path }}'
+  tags: [supervisord,supervisord-config]
+
+- name: Create config entries
+  template:
+    src: 'conf.d-entry.j2'
+    dest: '/etc/supervisor/conf.d/{{ item.name }}.conf'
+    owner: 'root'
+    group: 'root'
+  with_items: supervisord_programs
+  notify: Reload supervisord config
+  tags: [supervisord,supervisord-config]

--- a/supervisord/templates/conf.d-entry.j2
+++ b/supervisord/templates/conf.d-entry.j2
@@ -6,5 +6,6 @@ directory={{ item.directory }}
 numprocs={{ item.numprocs|default(supervisord_program_defaults.numprocs) }}
 autostart={{ item.autostart|default(supervisord_program_defaults.autostart)|lower }}
 autorestart={{ item.autorestart|default(supervisord_program_defaults.autorestart)|lower }}
+environment={{ item.environment|default(supervisord_program_defaults.environment) }}
 stderr_logfile={{ supervisord_log_path }}/{{ item.stderr_logfile|default('supervisor-' ~ item.name ~ '.err.log') }}
 stdout_logfile={{ supervisord_log_path }}/{{ item.stdout_logfile|default('supervisor-' ~ item.name ~ '.out.log') }}

--- a/supervisord/templates/conf.d-entry.j2
+++ b/supervisord/templates/conf.d-entry.j2
@@ -1,0 +1,9 @@
+[program:{{ item.name }}]
+command={{ item.command }}
+user={{ item.user }}
+directory={{ item.directory }}
+numprocs={{ item.numprocs|default(supervisord_program_defaults.numprocs) }}
+autostart={{ item.autostart|default(supervisord_program_defaults.autostart)|lower }}
+autorestart={{ item.autorestart|default(supervisord_program_defaults.autorestart)|lower }}
+stderr_logfile={{ supervisord_log_path }}/{{ item.stderr_logfile|default('supervisor-' ~ item.name ~ '.err.log') }}
+stdout_logfile={{ supervisord_log_path }}/{{ item.stdout_logfile|default('supervisor-' ~ item.name ~ '.out.log') }}

--- a/supervisord/templates/conf.d-entry.j2
+++ b/supervisord/templates/conf.d-entry.j2
@@ -1,4 +1,5 @@
 [program:{{ item.name }}]
+process_name=%(program_name)s_%(process_num)02d
 command={{ item.command }}
 user={{ item.user }}
 directory={{ item.directory }}

--- a/supervisord/vars/main.yml
+++ b/supervisord/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for supervisord


### PR DESCRIPTION
Tan fácil como definir variable "rabbitmq_plugins" como una lista de plugins separada por comas (por defecto está a false, no instala nada)
